### PR TITLE
fixing bug while creating tmp file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,20 @@
 TEST?=$$(go list ./... | grep -v 'vendor')
-HOSTNAME=joaoluna.com
 NAMESPACE=cloud
 NAME=akash
 BINARY=terraform-provider-${NAME}
 VERSION=0.0.5
 OS_ARCH=darwin_arm64
+OS := $(shell uname -s | tr A-Z a-z)
+HOSTNAME := $(shell hostname)
+UNAME := $(shell uname -m)
+
+ifeq ($(UNAME),x86_64)
+ARCH=amd64
+else ifeq ($(UNAME),i386)
+ARCH=386
+else ifeq ($(UNAME),arm64)
+ARCH=arm64
+endif
 
 default: install
 
@@ -27,8 +37,8 @@ release:
 	#GOOS=windows GOARCH=amd64 go build -o ./bin/${BINARY}_${VERSION}_windows_amd64
 
 install: build
-	mkdir -p ~/.terraform.d/plugins/${HOSTNAME}/${NAMESPACE}/${NAME}/${VERSION}/${OS_ARCH}
-	mv ${BINARY} ~/.terraform.d/plugins/${HOSTNAME}/${NAMESPACE}/${NAME}/${VERSION}/${OS_ARCH}
+	mkdir -p ~/.terraform.d/plugins/${HOSTNAME}/${NAMESPACE}/${NAME}/${VERSION}/${OS}_${ARCH}
+	mv ${BINARY} ~/.terraform.d/plugins/${HOSTNAME}/${NAMESPACE}/${NAME}/${VERSION}/${OS}_${ARCH}
 
 test: 
 	go test -i $(TEST) || exit 1

--- a/akash/file.go
+++ b/akash/file.go
@@ -11,7 +11,7 @@ import (
 
 func CreateTemporaryDeploymentFile(ctx context.Context, sdl string) (string, error) {
 	timestamp := time.Now().UnixNano()
-	filename := fmt.Sprintf("%sdeployment-%d.yaml", os.TempDir(), timestamp)
+	filename := fmt.Sprintf("%s/deployment-%d.yaml", os.TempDir(), timestamp)
 	tflog.Debug(ctx, fmt.Sprintf("Creating temporary deployment file %s", filename))
 
 	err := ioutil.WriteFile(filename, []byte(sdl), 0666)

--- a/akash/file.go
+++ b/akash/file.go
@@ -3,10 +3,11 @@ package akash
 import (
 	"context"
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"io/ioutil"
 	"os"
 	"time"
+
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 func CreateTemporaryDeploymentFile(ctx context.Context, sdl string) (string, error) {


### PR DESCRIPTION
os.TempDir() returns the path with  `/tmp`  which leads to  the function to try to create the temporary file in /tmpdeployment-<timestamp>.yaml 

Please refer to this https://github.com/golang/go/issues/21318  